### PR TITLE
Add Gradle build workflow for manual trigger on master

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,34 @@
+name: Gradle Build
+
+on:
+  workflow_dispatch:
+    # Only allow manual trigger on master
+    inputs:
+      dummy:
+        description: 'Manual trigger'
+        required: false
+  push:
+    branches: []  # disables on push
+  pull_request:
+    branches: []  # disables on PR
+
+jobs:
+  build:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build


### PR DESCRIPTION
Introduced a GitHub Actions workflow to manually trigger Gradle builds on the master branch. Includes steps for JDK setup, Gradle wrapper configuration, and build execution.