### PR TITLE
Add trailing stop-loss mechanism for sell signals

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,10 @@
 name: Build
 
 on:
-  workflow_dispatch:
-    # Manual trigger
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/src/main/java/ch/kekelidze/krakentrader/indicator/RiskManagementIndicator.java
+++ b/src/main/java/ch/kekelidze/krakentrader/indicator/RiskManagementIndicator.java
@@ -5,6 +5,8 @@ import ch.kekelidze.krakentrader.indicator.analyser.AtrAnalyser;
 import ch.kekelidze.krakentrader.indicator.configuration.StrategyParameters;
 import ch.kekelidze.krakentrader.strategy.dto.EvaluationContext;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -18,6 +20,8 @@ public class RiskManagementIndicator implements Indicator {
   private final AtrAnalyser atrAnalyser;
   private final TradingApiService krakenApiService;
 
+  private final Map<String, TrailingState> trailingStates = new ConcurrentHashMap<>();
+
   @Override
   public boolean isBuySignal(EvaluationContext context, StrategyParameters params) {
     return true;
@@ -27,16 +31,46 @@ public class RiskManagementIndicator implements Indicator {
   public boolean isSellSignal(EvaluationContext context, double entryPrice,
       StrategyParameters params) {
     var data = context.getBars();
+    var symbol = context.getSymbol();
+    var roundTripFeePercentage = calculateFeePercentage(symbol);
+
     var currentPrice = calculateDynamicStopLossPrice(data, params);
-    var roundTripFeePercentage = calculateFeePercentage(context.getSymbol());
+    double breakevenPrice = entryPrice * (1 + roundTripFeePercentage / 100);
+
     double adjustedLossPercent = params.lossPercent() - roundTripFeePercentage;
     double adjustedProfitPercent = params.profitPercent() + roundTripFeePercentage;
-    var stopLossTakeProfit = shouldStopLoss(entryPrice, currentPrice, adjustedLossPercent)
-        || shouldTakeProfit(entryPrice, currentPrice, adjustedProfitPercent);
-    log.debug(
-        "Dynamic price: {}, Entry price: {} | Should stop loss/take profit: {} | Closing time: {}",
-        currentPrice, entryPrice, stopLossTakeProfit, data.getLast().getEndTime());
-    return stopLossTakeProfit;
+
+    if (shouldStopLoss(entryPrice, currentPrice, adjustedLossPercent)) {
+      cleanupTrailingState(symbol);
+      log.debug("Stop loss triggered at price: {}, Entry: {} | Closing time: {} ",
+          currentPrice, entryPrice, data.getLast().getEndTime());
+      return true;
+    }
+
+    if (shouldTakeProfit(entryPrice, currentPrice, adjustedProfitPercent)) {
+      cleanupTrailingState(symbol);
+      log.debug("Take profit triggered at price: {}, Entry: {} | Closing time: {}",
+          currentPrice, entryPrice, data.getLast().getEndTime());
+      return true;
+    }
+
+    if (currentPrice > breakevenPrice) {
+      boolean shouldSell = shouldTrailingSell(symbol, currentPrice, breakevenPrice, params);
+      if (shouldSell) {
+        cleanupTrailingState(symbol);
+        log.debug("Trailing sell triggered at price: {}, Entry: {}, Breakeven: {}",
+            currentPrice, entryPrice, breakevenPrice);
+        return true;
+      }
+    } else {
+      // Reset trailing state if we're below breakeven
+      cleanupTrailingState(symbol);
+    }
+
+    log.debug("No sell signal - Price: {}, Entry: {}, Breakeven: {}, Closing time: {}",
+        currentPrice, entryPrice, breakevenPrice, data.getLast().getEndTime());
+    return false;
+
   }
 
   private double calculateFeePercentage(String coinPair) {
@@ -57,5 +91,58 @@ public class RiskManagementIndicator implements Indicator {
   private boolean shouldTakeProfit(double entryPrice, double currentPrice,
       double profitPercent) {
     return currentPrice >= entryPrice * (1 + profitPercent / 100);
+  }
+
+  private boolean shouldTrailingSell(String symbol, double currentPrice, double breakevenPrice,
+      StrategyParameters params) {
+    TrailingState state = trailingStates.computeIfAbsent(symbol, k -> new TrailingState());
+
+    // Update peak price if current price is higher
+    if (currentPrice > state.peakPrice) {
+      state.peakPrice = currentPrice;
+      state.consecutiveDeclines = 0;
+      state.isTrailingActive = true;
+      // Don't sell while the price is still rising
+      return false;
+    }
+
+    // Price has declined from peak
+    if (state.isTrailingActive && currentPrice < state.peakPrice) {
+      state.consecutiveDeclines++;
+
+      // Calculate decline percentage from peak
+      double declinePercent = ((state.peakPrice - currentPrice) / state.peakPrice) * 100;
+
+      double trailingThreshold = getTrailingThreshold(params);
+
+      // Sell if decline exceeds the threshold and we have consecutive declines
+      if (declinePercent >= trailingThreshold && state.consecutiveDeclines >= 2) {
+        // Additional safety check: ensure we're still above breakeven
+        if (currentPrice > breakevenPrice) {
+          log.debug("Trailing sell conditions met - "
+                  + "Peak: {}, Current: {}, Decline: {}%, Consecutive declines: {}",
+              state.peakPrice, currentPrice, declinePercent, state.consecutiveDeclines);
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private double getTrailingThreshold(StrategyParameters params) {
+    // For now, using a dynamic threshold based on volatility
+    // Higher volatility = higher threshold to avoid false signals
+    return Math.max(0.5, params.highVolatilityThreshold() * 0.5);
+  }
+
+  private void cleanupTrailingState(String symbol) {
+    trailingStates.remove(symbol);
+  }
+
+  private static class TrailingState {
+    double peakPrice = 0.0;
+    int consecutiveDeclines = 0;
+    boolean isTrailingActive = false;
   }
 }

--- a/src/test/java/ch/kekelidze/krakentrader/indicator/RiskManagementIndicatorTest.java
+++ b/src/test/java/ch/kekelidze/krakentrader/indicator/RiskManagementIndicatorTest.java
@@ -1,0 +1,130 @@
+package ch.kekelidze.krakentrader.indicator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ch.kekelidze.krakentrader.api.rest.service.TradingApiService;
+import ch.kekelidze.krakentrader.indicator.analyser.AtrAnalyser;
+import ch.kekelidze.krakentrader.indicator.configuration.StrategyParameters;
+import ch.kekelidze.krakentrader.strategy.dto.EvaluationContext;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBar;
+
+public class RiskManagementIndicatorTest {
+
+  private AtrAnalyser atrAnalyser;
+  private TradingApiService tradingApiService;
+  private RiskManagementIndicator indicator;
+
+  private static final String SYMBOL = "BTC/USD";
+  private static final double ENTRY_PRICE = 100.0;
+
+  @BeforeEach
+  void setUp() {
+    atrAnalyser = mock(AtrAnalyser.class);
+    tradingApiService = mock(TradingApiService.class);
+    indicator = new RiskManagementIndicator(atrAnalyser, tradingApiService);
+
+    // Simplify dynamic price: currentPrice = lastClose - (highVolatilityThreshold * ATR)
+    // We'll set ATR = 0 in tests -> currentPrice = lastClose
+    when(atrAnalyser.calculateATR(anyList(), anyInt())).thenReturn(0.0);
+
+    // Set taker fee so that breakeven = entry * (1 + 2*fee/100)
+    // Using 0.25% taker -> roundTrip 0.5% -> breakeven = 100.5 for ENTRY_PRICE=100
+    when(tradingApiService.getCoinTradingFee(SYMBOL)).thenReturn(0.25);
+  }
+
+  private static Bar bar(double close) {
+    ZonedDateTime now = ZonedDateTime.now();
+    return new BaseBar(Duration.ofMinutes(1), now, close, close, close, close, 1d);
+  }
+
+  private static EvaluationContext ctx(String symbol, List<Bar> bars) {
+    return EvaluationContext.builder()
+        .symbol(symbol)
+        .bars(bars)
+        .build();
+  }
+
+  private static StrategyParameters params(double lossPercent, double profitPercent,
+      double highVolatilityThreshold, int atrPeriod) {
+    return StrategyParameters.builder()
+        .lossPercent(lossPercent)
+        .profitPercent(profitPercent)
+        .highVolatilityThreshold(highVolatilityThreshold)
+        .atrPeriod(atrPeriod)
+        .build();
+  }
+
+  @Test
+  void trailingSell_triggersAfterTwoConsecutiveDeclinesAboveThreshold_andAboveBreakeven() {
+    // Given
+    // threshold = max(0.5, highVolatilityThreshold * 0.5). Set highVolatilityThreshold = 0 -> threshold = 0.5
+    StrategyParameters p = params(50.0, 1000.0, 0.0, 14);
+    double breakeven = ENTRY_PRICE * (1 + (0.25 * 2) / 100); // 100.5
+
+    // Sequence: Rise to 110 (activate trailing), then two declines 109 and 107
+    // Decline from peak 110 to 107 = ~2.727% >= 0.5% and 2 consecutive declines -> should sell
+
+    // 1) Rising to peak: 110
+    assertFalse(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(110))), ENTRY_PRICE, p));
+
+    // 2) First decline: 109 (above breakeven)
+    assertFalse(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(109))), ENTRY_PRICE, p));
+    assertTrue(109.0 > breakeven);
+
+    // 3) Second decline: 107 (above breakeven) -> should trigger
+    assertTrue(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(107))), ENTRY_PRICE, p));
+    assertTrue(107.0 > breakeven);
+  }
+
+  @Test
+  void trailingSell_doesNotTriggerOnSingleDecline() {
+    StrategyParameters p = params(50.0, 1000.0, 0.0, 14);
+
+    // Peak 105, then a single decline to 104.7 (0.2857% decline) < 0.5% and also only 1 decline -> no sell
+    assertFalse(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(105))), ENTRY_PRICE, p));
+    assertFalse(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(104.7))), ENTRY_PRICE, p));
+  }
+
+  @Test
+  void trailingSell_stateResetsWhenBelowBreakeven_andRequiresNewSequence() {
+    StrategyParameters p = params(50.0, 1000.0, 0.0, 14);
+
+    double breakeven = ENTRY_PRICE * (1 + (0.25 * 2) / 100); // 100.5
+
+    // 1) Go above breakeven and establish a peak
+    assertFalse(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(103))), ENTRY_PRICE, p));
+    assertFalse(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(104))), ENTRY_PRICE, p));
+
+    // 2) Drop below breakeven -> state should reset
+    assertFalse(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(100.4))), ENTRY_PRICE, p));
+    assertTrue(100.4 < breakeven);
+
+    // 3) Go above breakeven again: build a new peak sequence
+    assertFalse(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(106))), ENTRY_PRICE, p)); // new peak
+    assertFalse(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(105.8))), ENTRY_PRICE,
+        p)); // first small decline (<0.5%)
+
+    // Second small decline from peak, still below threshold -> should NOT trigger
+    assertFalse(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(105.6))), ENTRY_PRICE, p));
+
+    // Now make a new higher peak to reset decline count
+    assertFalse(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(107))), ENTRY_PRICE,
+        p)); // new higher peak resets declines
+    // Two proper declines after reset to trigger
+    assertFalse(
+        indicator.isSellSignal(ctx(SYMBOL, List.of(bar(106))), ENTRY_PRICE, p)); // first decline
+    assertTrue(indicator.isSellSignal(ctx(SYMBOL, List.of(bar(104.5))), ENTRY_PRICE,
+        p)); // second decline > threshold
+  }
+}


### PR DESCRIPTION
Introduced a trailing stop-loss feature to dynamically adjust sell thresholds based on peak price and consecutive declines. Updated risk management logic and added debug logs for enhanced strategy insights and traceability.